### PR TITLE
button 'save and edit'

### DIFF
--- a/app/forms/reseller.py
+++ b/app/forms/reseller.py
@@ -1,5 +1,5 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, IntegerField, SelectField
+from wtforms import StringField, IntegerField, SelectField, SubmitField
 from wtforms.validators import DataRequired
 from wtforms.widgets import TextArea
 
@@ -10,3 +10,4 @@ class ResellerForm(FlaskForm):
     status = SelectField("Activated:", default='active',
                          choices=[('not_active', 'Not Active'), ('active', 'Active')])
     comments = StringField("Comment:", widget=TextArea())
+    submit = SubmitField("Save")

--- a/app/js/reseller_edit.js
+++ b/app/js/reseller_edit.js
@@ -2,7 +2,7 @@
 $(document).ready(() => {
   let incommingResellerInfo = Array.from(document.querySelectorAll(".changeable")).map(el => (el.value));
   document.querySelectorAll(".redirector").forEach(button => button.addEventListener('click', e => {
-    targetLocation = e.currentTarget.href;
+    let targetLocation = e.currentTarget.href;
     let outgoingResellerInfo = Array.from(document.querySelectorAll(".changeable")).map(el => (el.value));
     if (JSON.stringify(incommingResellerInfo) != JSON.stringify(outgoingResellerInfo)) {
       e.preventDefault();

--- a/app/js/reseller_edit.js
+++ b/app/js/reseller_edit.js
@@ -1,0 +1,26 @@
+// custom javascript
+$(document).ready(() => {
+  let incommingResellerInfo = Array.from(document.querySelectorAll(".changeable")).map(el => (el.value));
+  document.querySelectorAll(".redirector").forEach(button => button.addEventListener('click', e => {
+    targetLocation = e.currentTarget.href;
+    let outgoingResellerInfo = Array.from(document.querySelectorAll(".changeable")).map(el => (el.value));
+    if (JSON.stringify(incommingResellerInfo) != JSON.stringify(outgoingResellerInfo)) {
+      e.preventDefault();
+      let formElement = document.querySelector('#main-form');
+      let formData = new FormData(formElement);
+      formData.set("submit", "save_and_edit");
+      fetch(formElement.action, {
+        method: 'POST',
+        body: formData
+      })
+        .then(response => {
+          if (response.status == 200) {
+            window.location.href = targetLocation;
+          } else {
+            alert('Server issues. Please, try this approach later!');
+            throw Error(response.statusText);
+          }
+        }).catch(error => console.log(error));
+    }
+  }))
+});

--- a/app/models/account.py
+++ b/app/models/account.py
@@ -25,7 +25,6 @@ class Account(db.Model, ModelMixin):
     product = relationship('Product')
     phone = relationship('Phone')
     reseller = relationship('Reseller')
-    # changes = relationship('AccountChanges', )
 
     @staticmethod
     def __add_months(sourcedate: datetime, months: int) -> datetime:

--- a/app/models/account.py
+++ b/app/models/account.py
@@ -25,6 +25,7 @@ class Account(db.Model, ModelMixin):
     product = relationship('Product')
     phone = relationship('Phone')
     reseller = relationship('Reseller')
+    # changes = relationship('AccountChanges', )
 
     @staticmethod
     def __add_months(sourcedate: datetime, months: int) -> datetime:
@@ -49,10 +50,12 @@ class Account(db.Model, ModelMixin):
             'sim': self.sim,
             'expiration_date': self.expiration_date.strftime("%Y-%m-%d"),
             'activation_date': self.activation_date.strftime("%Y-%m-%d"),
-            'months': self.months
+            'months': self.months,
+            'prev_names': ", ".join([change.value_str for change in self.changes.filter_by(change_type='name').all()]),
+            'prev_sims': ", ".join([change.value_str for change in self.changes.filter_by(change_type='sim').all()])
         }
 
     @staticmethod
     def columns():
         return ['ID', 'Name', 'Product', 'Phone', 'IMEI',
-                'Re-seller', 'SIM', 'Expiration Date', 'Activation Date', 'Months']
+                'Re-seller', 'SIM', 'Expiration Date', 'Activation Date', 'Months', 'Prev. names', 'Prev. SIMs']

--- a/app/models/account_changes.py
+++ b/app/models/account_changes.py
@@ -20,4 +20,4 @@ class AccountChanges(db.Model, ModelMixin):
     date = db.Column(db.DateTime, default=datetime.now)
     change_type = db.Column(Enum(ChangeType), default=ChangeType.name)
     value_str = db.Column(db.String(60), nullable=False)
-    account = relationship('Account')
+    account = relationship('Account', backref=db.backref("changes", lazy="dynamic"))

--- a/app/models/product.py
+++ b/app/models/product.py
@@ -28,3 +28,8 @@ class Product(db.Model, ModelMixin):
     @staticmethod
     def columns():
         return ['ID', 'Name', 'Status']
+
+
+@classmethod
+def get_ordered_by_name_desc(cls):
+    return cls.query.filter(cls.deleted == False).order_by(cls.name).all()  # noqa E712

--- a/app/ninja/invoice.py
+++ b/app/ninja/invoice.py
@@ -45,16 +45,18 @@ class NinjaInvoice(object):
             'cost': cost,
             'qty': qty
             }]
-        return self.save()
+        result = self.save()
+        return result if result else None
 
     def delete_item(self, invoice_items):
         self.invoice_items = [data for data in self.invoice_items if data['invoice_items'] != invoice_items]
 
     def save(self):
         log(log.DEBUG, 'NinjaApi.update_product %d', self.id)
-        return api.do_put(
+        api_result = api.do_put(
             '{}invoices/{}'.format(api.BASE_URL, self.id),
             **(self.to_dict()))
+        return api_result if api_result else None
 
     @staticmethod
     def get(invoice_id: int): # noqa E999

--- a/app/ninja/ninja_api.py
+++ b/app/ninja/ninja_api.py
@@ -78,7 +78,7 @@ class NinjaApi(object):
             response.raise_for_status()
         except requests.HTTPError as error:
             log(log.ERROR, "NinjaApi.HTTPError: %s", error)
-        return response.ok
+        return response.ok if response.ok else None
 
     @property
     def clients(self):

--- a/app/templates/account_details.html
+++ b/app/templates/account_details.html
@@ -171,11 +171,12 @@
 </div>
 {% endif %}
 {% if form.is_edit and form.name_changes %}
+<br>
 <div class="row">
     <label class="col-sm-4 col-form-label ">Account history:</label>
 </div>
 {%for change in form.name_changes %}
-<div class="row mt-2">
+<div class="row mb-2">
     <label class="col-sm-1 col-form-label">Name:</label>
     <div class="col-sm-4 mx-3 form-control" readonly> {{change.value_str}} </div>
     <label class="d-inline-flex  col-form-label">Change date:</label>
@@ -188,7 +189,7 @@
 {% endfor %}
 {% endif %}
 {% if form.is_edit and form.sim_changes %}
-<br>
+
 <div class="row">
     <label class="col-sm-4 col-form-label ">SIM history:</label>
 </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,7 +21,7 @@
   {% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}
   {% for category, message in messages %}
-  <div class="alert alert-{{ category }} alert-dismisible">
+  <div class="mt-3 alert alert-{{ category }} alert-dismisible">
     <button type="button" class="close" data-dismiss="alert" aria-label="Close">
       <span aria-hidden="true">&times;</span>
       <span class="sr-only">Close</span>

--- a/app/templates/base_add_edit.html
+++ b/app/templates/base_add_edit.html
@@ -17,24 +17,12 @@
 
 <body>
   <div class="container">
-    <!-- <div class="row "> -->
-    <!-- <div class="col-lg-8 d-inline-flex "> -->
     <div class="card">
       <div class="card-header px-0 py-0">
-        <div class="container">
-          <nav class="navbar navbar-expand-lg navbar-light"></nav>
-          <div class="row justify-content-between">
-            <div class="col-4">
-              <a class="navbar-brand" href="{{ form.close_button }}">NITRIX</a>
-            </div>
-            <div class="col-1">
-              <a type="button" class="close" aria-label="Close" href="{{ form.close_button }}">
-               x
-              </a>
-            </div>
-          </div>
-          </nav>
-        </div>
+        <nav class="navbar navbar-expand-lg navbar-light d-flex justify-content-between">
+                <a class="navbar-brand" href="{{ form.close_button }}">NITRIX</a>
+                <a class="btn btn-outline-secondary btn-sm my-sm-0" href="{{ form.close_button }}">X</a>
+        </nav>
       </div>
       <div class="card-body px-0 py-0">
         {% with messages = get_flashed_messages(with_categories=true) %}
@@ -88,11 +76,13 @@
         <div class="card-footer mt-6">
           <div class="row">
             <div class="col-sm-4 my-1 d-flex justify-content-around">
-              <button class="btn btn-success btn-lg btn-block" type="submit" name="submit" form="main-form" value="save">Save</button>
+              <button class="btn btn-success btn-lg btn-block" type="submit" name="submit" form="main-form"
+                value="save">Save</button>
             </div>
             {% if form.is_edit %}
             <div class="col-sm-4 my-1 d-flex justify-content-around">
-              <button class="btn btn-success btn-lg btn-block" type="submit" name="submit" form="main-form" value="save_and_edit">Save
+              <button class="btn btn-success btn-lg btn-block" type="submit" name="submit" form="main-form"
+                value="save_and_edit">Save
                 and edit</button>
             </div>
             <div class="col-sm-4 my-1 d-flex justify-content-around">
@@ -112,7 +102,8 @@
               </div>
               {% if form.is_edit %}
               <div class="col-sm-6 my-1 d-flex justify-content-around">
-                <a href="{{ form.delete_route}}?id={{ form.id.data }}" class="btn btn-danger btn-lg btn-block">Delete</a>
+                <a href="{{ form.delete_route}}?id={{ form.id.data }}"
+                  class="btn btn-danger btn-lg btn-block">Delete</a>
               </div>
               {% endif %}
             </div>
@@ -126,17 +117,15 @@
 
     <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
       integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous">
-    </script>
+      </script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
       integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous">
-    </script>
+      </script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
       integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous">
-    </script>
+      </script>
     {% block javascript %}
     {% endblock %}
-    <!-- </div> -->
-    <!-- </div> -->
   </div>
 
 </body>

--- a/app/templates/base_add_edit.html
+++ b/app/templates/base_add_edit.html
@@ -87,11 +87,15 @@
         {% endblock %}
         <div class="card-footer mt-6">
           <div class="row">
-            <div class="col-sm-6 my-1 d-flex justify-content-around">
-              <button class="btn btn-success btn-lg btn-block" type="submit" form="main-form">Save</button>
+            <div class="col-sm-4 my-1 d-flex justify-content-around">
+              <button class="btn btn-success btn-lg btn-block" type="submit" name="submit" form="main-form" value="save">Save</button>
             </div>
             {% if form.is_edit %}
-            <div class="col-sm-6 my-1 d-flex justify-content-around">
+            <div class="col-sm-4 my-1 d-flex justify-content-around">
+              <button class="btn btn-success btn-lg btn-block" type="submit" name="submit" form="main-form" value="save_and_edit">Save
+                and edit</button>
+            </div>
+            <div class="col-sm-4 my-1 d-flex justify-content-around">
               <a href="{{ form.delete_route}}?id={{ form.id.data }}" class="btn btn-danger btn-lg btn-block">Delete</a>
             </div>
             {% endif %}

--- a/app/templates/base_add_edit.html
+++ b/app/templates/base_add_edit.html
@@ -25,7 +25,7 @@
           <nav class="navbar navbar-expand-lg navbar-light"></nav>
           <div class="row justify-content-between">
             <div class="col-4">
-              <a class="navbar-brand" href="/">NITRIX</a>
+              <a class="navbar-brand" href="{{ form.close_button }}">NITRIX</a>
             </div>
             <div class="col-1">
               <a type="button" class="close" aria-label="Close" href="{{ form.close_button }}">

--- a/app/templates/base_add_edit.html
+++ b/app/templates/base_add_edit.html
@@ -42,7 +42,7 @@
         <!-- Flash Messages Begin -->
         <div class="container">
           {% for category, message in messages %}
-          <div class="alert alert-{{ category }} alert-dismissible">
+          <div class="mt-3 alert alert-{{ category }} alert-dismissible">
             <button type="button" class="close" data-dismiss="alert" aria-label="Close">
               <span aria-hidden="true">&times;</span>
               <span class="sr-only">Close</span>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -17,7 +17,7 @@
 </head>
 
 <body>
-  <div class="container-fluid">
+  <!-- <div class="container-fluid"> -->
       <nav class="navbar navbar-expand-sm navbar-light">
         <a class="navbar-brand" href="/">NITRIX</a>
         <div class="navbar-collapse" id="navbarSupportedContent">
@@ -44,9 +44,9 @@
             </form>
           </ul>
         </div>
-          <a class="" href="{{url_for('main.report', content=main_content)}}">report</a>
+          <a class="btn btn-outline-secondary my-sm-0" href="{{url_for('main.report', content=main_content)}}">Report</a>
       </nav>
-  </div>
+  <!-- </div> -->
   <div class="mt-3 container-fluid">
     <!-- Flash Messages -->
     {% with messages = get_flashed_messages(with_categories=true) %}
@@ -90,8 +90,11 @@
   </div>
       <!-- Footer -->
   <div class="fixed-bottom bg-dark text-white">
-    NITRIX-2020
-    <a href="{{url_for('auth.logout')}}">Logout</a>
+    <div class="container-fluid">
+      NITRIX-2020
+      <a class="btn btn-dark" href="{{url_for('auth.logout')}}">Logout</a>
+    </div>
+
   </div>
     <!-- JS -->
   <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -47,6 +47,7 @@
           <a class="" href="{{url_for('main.report', content=main_content)}}">report</a>
       </nav>
   </div>
+  <div class="mt-3 container-fluid">
     <!-- Flash Messages -->
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -61,49 +62,49 @@
     {% endfor %}
     {% endif %}
     {% endwith %}
-    <!-- Content table -->
-    <div class="container-fluid mt-5 table-responsive">
-      <table id="theTable" class="table table-striped table-sm" cellspacing="0" width="100%">
-        <thead class="black white-text bg-secondary">
-          <tr>
-            {% for value in columns %}
-            <th>{{value}}</th>
-            {%endfor%}
-          </tr>
-        </thead>
-        <tbody>
-          {% for record in table_data %}
-          <tr id="{{record.id}}">
-            {% for key in record %}
-            {% if key == 'name' %}
-            <td> <a href="{{ edit_href }}?id={{record['id']}}">{{ record[key] }}</a> </td>
-            {% else %}
-            <td>{{ record[key] }}</td>
-            {% endif %}
-            {%endfor%}
-          </tr>
-          {%endfor%}
-        </tbody>
-      </table>
-    </div>
-      <!-- Futer -->
-    <div class="fixed-bottom bg-dark text-white">
-      NITRIX-2020
-      <a href="{{url_for('auth.logout')}}">Logout</a>
-    </div>
-      <!-- JS -->
-    <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
-      integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
-      crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
-      integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
-      crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
-      integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6"
-      crossorigin="anonymous"></script>
-    <script src="js/jquery.dataTables.min.js"></script>
-    <!-- Main JavaScript -->
-    <script src="js/main.js"></script>
   </div>
+    <!-- Content table -->
+  <div class="container-fluid mt-5 table-responsive">
+    <table id="theTable" class="table table-striped table-sm" cellspacing="0" width="100%">
+      <thead class="black white-text bg-secondary">
+        <tr>
+          {% for value in columns %}
+          <th>{{value}}</th>
+          {%endfor%}
+        </tr>
+      </thead>
+      <tbody>
+        {% for record in table_data %}
+        <tr id="{{record.id}}">
+          {% for key in record %}
+          {% if key == 'name' %}
+          <td> <a href="{{ edit_href }}?id={{record['id']}}">{{ record[key] }}</a> </td>
+          {% else %}
+          <td>{{ record[key] }}</td>
+          {% endif %}
+          {%endfor%}
+        </tr>
+        {%endfor%}
+      </tbody>
+    </table>
+  </div>
+      <!-- Footer -->
+  <div class="fixed-bottom bg-dark text-white">
+    NITRIX-2020
+    <a href="{{url_for('auth.logout')}}">Logout</a>
+  </div>
+    <!-- JS -->
+  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
+    integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
+    integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
+    crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
+    integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6"
+    crossorigin="anonymous"></script>
+  <script src="js/jquery.dataTables.min.js"></script>
+  <!-- Main JavaScript -->
+  <script src="js/main.js"></script>
 </body>
 </html>

--- a/app/templates/reseller_add_edit.html
+++ b/app/templates/reseller_add_edit.html
@@ -14,19 +14,19 @@
       {{form.id(type='hidden')}}
       {{form.name.label(class="col-sm-2 col-form-label")}}
       <div class="col-sm-10">
-        {{form.name(class='form-control')}}
+        {{form.name(class='form-control changeable')}}
       </div>
     </div>
     <div class="form-group row">
       {{form.status.label(class="col-sm-2 col-form-label")}}
       <div class="col-sm-10">
-        {{form.status(class='form-control')}}
+        {{form.status(class='form-control changeable')}}
       </div>
     </div>
     <div class="form-group row">
       {{form.comments.label(class="col-sm-2 col-form-label")}}
       <div class="col-sm-10">
-        {{form.comments(class='form-control')}}
+        {{form.comments(class='form-control changeable')}}
       </div>
     </div>
   </form>
@@ -43,7 +43,7 @@
       {% for prod_form in form.product_forms %}
       <tr>
         <th scope="row">
-          <a
+          <a class="redirector"
             {{'href=' + url_for('reseller_product.edit', _external=True, id=prod_form.id.data)}}>{{prod_form.product_name.data}}</a>
           <a type="button" class="close" aria-label="Delete"
             {{'href=' + url_for('reseller_product.delete', _external=True, id=prod_form.id.data)}}>
@@ -62,8 +62,13 @@
 {% if form.is_edit %}
 <div class="form-group">
   <a href="{{url_for('reseller_product.add')}}?reseller_id={{ form.id.data }}" type="button"
-    class="btn btn-primary btn-lg btn-block">Add product</a>
+    class="btn btn-primary btn-lg btn-block redirector">Add product</a>
 </div>
 {%endif%}
 </div>
+
+{% endblock %}
+
+{% block javascript %}
+<script src="js/reseller_edit.js"></script>
 {% endblock %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -20,3 +20,13 @@ class ModelMixin(object):
 
 def ninja_product_name(product_name: str, months: int):
     return f'{product_name} {months} Months'
+
+
+def organize_list_starting_with_value(input_list, value):
+    try:
+        default_phone_value_index = input_list.index([item for item in input_list if item.name == value][0])
+    except ValueError:
+        return input_list
+    default_value = input_list.pop(default_phone_value_index)
+    input_list.insert(0, default_value)
+    return input_list

--- a/app/views/account.py
+++ b/app/views/account.py
@@ -17,7 +17,7 @@ from app.forms import AccountForm
 from ..database import db
 from app.logger import log
 from app.ninja import NinjaInvoice
-from app.utils import ninja_product_name
+from app.utils import ninja_product_name, organize_list_starting_with_value
 from app.ninja import api as ninja
 
 
@@ -32,16 +32,6 @@ def all_phones():
     all_phones = phones.all()
     all_phones = organize_list_starting_with_value(all_phones, 'None')
     return all_phones
-
-
-def organize_list_starting_with_value(input_list, value):
-    try:
-        default_phone_value_index = input_list.index([item for item in input_list if item.name == value][0])
-    except ValueError:
-        return input_list
-    default_value = input_list.pop(default_phone_value_index)
-    input_list.insert(0, default_value)
-    return input_list
 
 
 @account_blueprint.route("/account_details")
@@ -124,8 +114,6 @@ def add_ninja_invoice(account: Account, is_new: bool, mode: str):
             .filter(ResellerProduct.months == account.months)
             .first()
         )
-    # First day of month TODO: not today! account.activation_date!
-    # invoice_date = datetime(datetime.now().year, datetime.now().month, 1)  # TODO: old impl "monthly"
     invoice_date = account.activation_date.strftime("%Y-%m-%d")
     current_invoice = None
     for invoice in NinjaInvoice.all():

--- a/app/views/account.py
+++ b/app/views/account.py
@@ -200,8 +200,8 @@ def save():
             # Add a new account
             if Account.query.filter(Account.name == form.name.data, Account.product_id == form.product_id.data).first():
                 log(log.WARNING, "Attempt to register account with existing credentials")
-                flash('Such account already exists', 'error')
-                return redirect(url_for("account.edit", id=form.id.data))
+                flash('Such account already exists', 'danger')
+                return redirect(url_for("account.edit"))
             new_account = True
             if form.sim_cost.data == 'yes':
                 form.comment.data += f'\r\n\r\n{SIM_COST_ACCOUNT_COMMENT}'

--- a/app/views/account.py
+++ b/app/views/account.py
@@ -87,7 +87,12 @@ def edit():
             prev_reseller = request.args['prev_reseller']
         form = AccountForm()
         form.products = organize_list_starting_with_value(
-            Product.query.order_by(Product.name).all(), prev_product) if prev_product else Product.query.all()
+            Product
+            .query
+            .filter(Product.deleted == False)  # noqa E712
+            .order_by(Product.name)
+            .all(),
+            prev_product) if prev_product else Product.query.all()
         form.resellers = organize_list_starting_with_value(
             Reseller.query.order_by(Reseller.name).all(),
             prev_reseller if prev_reseller else 'NITRIX')

--- a/app/views/account.py
+++ b/app/views/account.py
@@ -90,9 +90,17 @@ def edit():
         form.reseller_name = account.reseller.name
         return render_template("account_details.html", form=form)
     else:
+        prev_product = None
+        prev_reseller = None
+        if 'prev_reseller' in request.args and 'prev_product' in request.args:
+            prev_product = request.args['prev_product']
+            prev_reseller = request.args['prev_reseller']
         form = AccountForm()
-        form.products = Product.query.all()
-        form.resellers = organize_list_starting_with_value(Reseller.query.order_by(Reseller.name).all(), 'NITRIX')
+        form.products = organize_list_starting_with_value(
+            Product.query.order_by(Product.name).all(), prev_product) if prev_product else Product.query.all()
+        form.resellers = organize_list_starting_with_value(
+            Reseller.query.order_by(Reseller.name).all(),
+            prev_reseller if prev_reseller else 'NITRIX')
         form.phones = all_phones()
         form.is_edit = False
         form.save_route = url_for("account.save")
@@ -235,7 +243,13 @@ def save():
 
         log(log.INFO, "Account data was saved")
         if request.form["submit"] == "save_and_add":
-            return redirect(url_for("account.edit"))
+            return redirect(
+                url_for(
+                    "account.edit",
+                    prev_reseller=account.reseller.name,
+                    prev_product=account.product.name
+                )
+            )
         if request.form["submit"] == "save_and_edit":
             return redirect(url_for("account.edit", id=account.id))
         return redirect(url_for("main.accounts"))

--- a/app/views/account_extension.py
+++ b/app/views/account_extension.py
@@ -99,7 +99,7 @@ def save_new():
     account.is_new = False
     # Register product in Invoice Ninja
     if ninja.configured and not app.config['TESTING']:
-        add_ninja_invoice(account, False)
+        add_ninja_invoice(account, False, 'Extended')
     return redirect(url_for('account.edit', id=form.id.data))
 
 

--- a/app/views/account_extension.py
+++ b/app/views/account_extension.py
@@ -7,7 +7,7 @@ from app.models import Account, AccountExtension, Product, Reseller
 from app.forms import AccountExtensionForm
 from app.logger import log
 from app.ninja import api as ninja
-
+from app.utils import organize_list_starting_with_value
 from app.views.account import add_ninja_invoice
 
 account_extension_blueprint = Blueprint('account_extension', __name__)
@@ -26,8 +26,8 @@ def add():
         return redirect(url_for('main.accounts'))
     account_id = int(request.args['id'])
     form = AccountExtensionForm(id=account_id)
-    form.products = Product.query.filter(Product.deleted == False).all() # noqa E712
-    form.resellers = Reseller.query.filter(Reseller.deleted == False).all()  # noqa E712
+    form.products = Product.query.filter(Product.deleted == False).order_by(Product.name).all() # noqa E712
+    form.resellers = organize_list_starting_with_value(Reseller.query.order_by(Reseller.name).all(), 'NITRIX')  # noqa E712
     form.is_edit = False
     form.save_route = url_for('account_extension.save_new')
     form.close_button = url_for('account.edit', id=account_id)

--- a/app/views/reseller.py
+++ b/app/views/reseller.py
@@ -92,6 +92,8 @@ def save():
         reseller.save()
         log(log.INFO, "Reseller was saved")
         if form.id.data > 0:
+            if request.form["submit"] == "save_and_edit":
+                return redirect(url_for("reseller.edit", id=reseller.id))
             return redirect(url_for("main.resellers"))
         return redirect(url_for("reseller.edit", id=reseller.id))
     else:

--- a/tests/test_reseller.py
+++ b/tests/test_reseller.py
@@ -46,7 +46,7 @@ def test_save_reseller(client):
     # edit exists reseller
     response = client.post(
         '/reseller_save',
-        data=dict(id=1, name='ANOTHER RESELLER NAME', status='not_active'),
+        data=dict(id=1, name='ANOTHER RESELLER NAME', status='not_active', submit='save'),
         follow_redirects=True
     )
     assert response.status_code == 200


### PR DESCRIPTION
1. Added button 'save and edit' to reseller details and edition page so clients could stay on the same page after saving changes in reseller info.
2. Corrected redirects from entities` details pages to appropriate entity list table, instead of redirecting to users table (feature for super admins) 
3. Corrected redirection when entered existing account and product names. Now it redirects to account edit instead of account list page.
4. Added feature to remember last product and resseller and placing them in account form in account details/edit page.
5. Added ordering of resselers and roducts fields in account extension page.
6. Added feature to save reseller info, if changed, when moving to reseller product add/edit pages.
7. In accounts table page, added columns of previous account names and sims, so they could be filtered out.